### PR TITLE
Add Apple Silicon versions to casks

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -1,6 +1,7 @@
 name: Auto-update casks on new releases
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 * * * *"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-10.15, macos-11]
+        os: [macos-11]
 
     steps:
       - name: Set up Homebrew

--- a/Casks/trader-workstation-beta.rb
+++ b/Casks/trader-workstation-beta.rb
@@ -10,7 +10,7 @@ cask "trader-workstation-beta" do
 
   url "https://download2.interactivebrokers.com/installers/tws/beta/tws-beta-#{os}-#{arch}.dmg"
   name "Trader Workstation Beta"
-  desc "Trader Workstation Beta"
+  desc "Beta of Trader Workstation"
   homepage "https://www.interactivebrokers.com/"
 
   livecheck do

--- a/Casks/trader-workstation-beta.rb
+++ b/Casks/trader-workstation-beta.rb
@@ -2,12 +2,15 @@
 # frozen_string_literal: true
 
 cask "trader-workstation-beta" do
+  arch arm: "arm", intel: "x64"
+  os = on_arch_conditional arm: "macos", intel: "macosx"
+
   version "10.24.0b"
   sha256 :no_check
 
-  url "https://download2.interactivebrokers.com/installers/tws/beta/tws-beta-macosx-x64.dmg"
+  url "https://download2.interactivebrokers.com/installers/tws/beta/tws-beta-#{os}-#{arch}.dmg"
   name "Trader Workstation Beta"
-  desc "Beta Trader Workstation"
+  desc "Trader Workstation Beta"
   homepage "https://www.interactivebrokers.com/"
 
   livecheck do
@@ -23,13 +26,23 @@ cask "trader-workstation-beta" do
     args:       ["-q"],
   }
 
-  uninstall quit:   "com.install4j.5889-6375-8446-2021.22",
+  uninstall_preflight do
+    ohai "Stopping all running instances of Trader Workstation prior to uninstall"
+    system_command "/usr/bin/pkill", args: ["-f", "#{appdir}/Trader Workstation/Trader Workstation.app"]
+
+  rescue RuntimeError
+    ohai "No running instances of Trader Workstation found"
+  end
+
+  uninstall quit:   "com.install4j.5889-6375-8446-2021",
             script: {
               executable: "#{appdir}/Trader Workstation/Trader Workstation Uninstaller.app/Contents/MacOS/JavaApplicationStub",
               args:       ["-q"],
             }
 
-  caveats do
-    depends_on_java "7+"
-  end
+  zap trash: [
+    "#{appdir}/Trader Workstation",
+    "~/Jts",
+    "~/Library/Application Support/Trader Workstation",
+  ]
 end

--- a/Casks/trader-workstation-latest.rb
+++ b/Casks/trader-workstation-latest.rb
@@ -35,7 +35,7 @@ cask "trader-workstation-latest" do
 
   uninstall quit:   "com.install4j.5889-6375-8446-2021",
             script: {
-              executable: "#{appdir}/Trader Workstation #{version.major_minor}/Trader Workstation #{version.major} Uninstaller.app/Contents/MacOS/JavaApplicationStub",
+              executable: "#{appdir}/Trader Workstation #{version.major_minor}/Trader Workstation #{version.major_minor} Uninstaller.app/Contents/MacOS/JavaApplicationStub",
               args:       ["-q"],
             }
 

--- a/Casks/trader-workstation-latest.rb
+++ b/Casks/trader-workstation-latest.rb
@@ -2,12 +2,15 @@
 # frozen_string_literal: true
 
 cask "trader-workstation-latest" do
+  arch arm: "arm", intel: "x64"
+  os = on_arch_conditional arm: "macos", intel: "macosx"
+
   version "10.23.1q"
   sha256 :no_check
 
-  url "https://download2.interactivebrokers.com/installers/tws/latest-standalone/tws-latest-standalone-macosx-x64.dmg"
+  url "https://download2.interactivebrokers.com/installers/tws/latest-standalone/tws-latest-standalone-#{os}-#{arch}.dmg"
   name "Trader Workstation Latest"
-  desc "Latest Standalone Trader Workstation"
+  desc "Trader Workstation Standalone Latest"
   homepage "https://www.interactivebrokers.com/"
 
   livecheck do
@@ -18,17 +21,27 @@ cask "trader-workstation-latest" do
   conflicts_with cask: ["trader-workstation", "trader-workstation-stable", "trader-workstation-beta"]
 
   installer script: {
-    executable: "#{staged_path}/Trader Workstation #{version.major_minor} Installer.app/Contents/MacOS/JavaApplicationStub",
+    executable: "#{staged_path}/Trader Workstation Installer.app/Contents/MacOS/JavaApplicationStub",
     args:       ["-q"],
   }
 
-  uninstall quit:   "com.install4j.5889-6375-8446-2021.22",
+  uninstall_preflight do
+    ohai "Stopping all running instances of Trader Workstation prior to uninstall"
+    system_command "/usr/bin/pkill", args: ["-f", "#{appdir}/Trader Workstation/Trader Workstation.app"]
+
+  rescue RuntimeError
+    ohai "No running instances of Trader Workstation found"
+  end
+
+  uninstall quit:   "com.install4j.5889-6375-8446-2021",
             script: {
-              executable: "#{appdir}/Trader Workstation #{version.major_minor}/Trader Workstation #{version.major_minor} Uninstaller.app/Contents/MacOS/JavaApplicationStub",
+              executable: "#{appdir}/Trader Workstation/Trader Workstation Uninstaller.app/Contents/MacOS/JavaApplicationStub",
               args:       ["-q"],
             }
 
-  caveats do
-    depends_on_java "7+"
-  end
+  zap trash: [
+    "#{appdir}/Trader Workstation",
+    "~/Jts",
+    "~/Library/Application Support/Trader Workstation",
+  ]
 end

--- a/Casks/trader-workstation-latest.rb
+++ b/Casks/trader-workstation-latest.rb
@@ -21,13 +21,13 @@ cask "trader-workstation-latest" do
   conflicts_with cask: ["trader-workstation", "trader-workstation-stable", "trader-workstation-beta"]
 
   installer script: {
-    executable: "#{staged_path}/Trader Workstation Installer.app/Contents/MacOS/JavaApplicationStub",
+    executable: "#{staged_path}/Trader Workstation #{version.major_minor} Installer.app/Contents/MacOS/JavaApplicationStub",
     args:       ["-q"],
   }
 
   uninstall_preflight do
     ohai "Stopping all running instances of Trader Workstation prior to uninstall"
-    system_command "/usr/bin/pkill", args: ["-f", "#{appdir}/Trader Workstation/Trader Workstation.app"]
+    system_command "/usr/bin/pkill", args: ["-f", "#{appdir}/Trader Workstation #{version.major_minor}/Trader Workstation.app"]
 
   rescue RuntimeError
     ohai "No running instances of Trader Workstation found"
@@ -35,13 +35,13 @@ cask "trader-workstation-latest" do
 
   uninstall quit:   "com.install4j.5889-6375-8446-2021",
             script: {
-              executable: "#{appdir}/Trader Workstation/Trader Workstation Uninstaller.app/Contents/MacOS/JavaApplicationStub",
+              executable: "#{appdir}/Trader Workstation #{version.major_minor}/Trader Workstation #{version.major} Uninstaller.app/Contents/MacOS/JavaApplicationStub",
               args:       ["-q"],
             }
 
   zap trash: [
-    "#{appdir}/Trader Workstation",
+    "#{appdir}/Trader Workstation #{version.major_minor}",
     "~/Jts",
-    "~/Library/Application Support/Trader Workstation",
+    "~/Library/Application Support/Trader Workstation #{version.major_minor}",
   ]
 end

--- a/Casks/trader-workstation-latest.rb
+++ b/Casks/trader-workstation-latest.rb
@@ -10,7 +10,7 @@ cask "trader-workstation-latest" do
 
   url "https://download2.interactivebrokers.com/installers/tws/latest-standalone/tws-latest-standalone-#{os}-#{arch}.dmg"
   name "Trader Workstation Latest"
-  desc "Trader Workstation Standalone Latest"
+  desc "Standalone of Trader Workstation Latest"
   homepage "https://www.interactivebrokers.com/"
 
   livecheck do

--- a/Casks/trader-workstation-stable.rb
+++ b/Casks/trader-workstation-stable.rb
@@ -35,7 +35,7 @@ cask "trader-workstation-stable" do
 
   uninstall quit:   "com.install4j.5889-6375-8446-2021",
             script: {
-              executable: "#{appdir}/Trader Workstation #{version.major_minor}/Trader Workstation #{version.major} Uninstaller.app/Contents/MacOS/JavaApplicationStub",
+              executable: "#{appdir}/Trader Workstation #{version.major_minor}/Trader Workstation #{version.major_minor} Uninstaller.app/Contents/MacOS/JavaApplicationStub",
               args:       ["-q"],
             }
 

--- a/Casks/trader-workstation-stable.rb
+++ b/Casks/trader-workstation-stable.rb
@@ -10,7 +10,7 @@ cask "trader-workstation-stable" do
 
   url "https://download2.interactivebrokers.com/installers/tws/stable-standalone/tws-stable-standalone-#{os}-#{arch}.dmg"
   name "Trader Workstation"
-  desc "Trader Workstation Standalone Stable"
+  desc "Standalone of Trader Workstation Stable"
   homepage "https://www.interactivebrokers.com/"
 
   livecheck do
@@ -38,7 +38,7 @@ cask "trader-workstation-stable" do
               executable: "#{appdir}/Trader Workstation/Trader Workstation Uninstaller.app/Contents/MacOS/JavaApplicationStub",
               args:       ["-q"],
             }
-  
+
   zap trash: [
     "#{appdir}/Trader Workstation",
     "~/Jts",

--- a/Casks/trader-workstation-stable.rb
+++ b/Casks/trader-workstation-stable.rb
@@ -21,13 +21,13 @@ cask "trader-workstation-stable" do
   conflicts_with cask: ["trader-workstation", "trader-workstation-latest", "trader-workstation-beta"]
 
   installer script: {
-    executable: "#{staged_path}/Trader Workstation Installer.app/Contents/MacOS/JavaApplicationStub",
+    executable: "#{staged_path}/Trader Workstation #{version.major_minor} Installer.app/Contents/MacOS/JavaApplicationStub",
     args:       ["-q"],
   }
 
   uninstall_preflight do
     ohai "Stopping all running instances of Trader Workstation prior to uninstall"
-    system_command "/usr/bin/pkill", args: ["-f", "#{appdir}/Trader Workstation/Trader Workstation.app"]
+    system_command "/usr/bin/pkill", args: ["-f", "#{appdir}/Trader Workstation #{version.major_minor}/Trader Workstation.app"]
 
   rescue RuntimeError
     ohai "No running instances of Trader Workstation found"
@@ -35,13 +35,13 @@ cask "trader-workstation-stable" do
 
   uninstall quit:   "com.install4j.5889-6375-8446-2021",
             script: {
-              executable: "#{appdir}/Trader Workstation/Trader Workstation Uninstaller.app/Contents/MacOS/JavaApplicationStub",
+              executable: "#{appdir}/Trader Workstation/Trader Workstation #{version.major_minor} Uninstaller.app/Contents/MacOS/JavaApplicationStub",
               args:       ["-q"],
             }
 
   zap trash: [
-    "#{appdir}/Trader Workstation",
+    "#{appdir}/Trader Workstation #{version.major_minor}",
     "~/Jts",
-    "~/Library/Application Support/Trader Workstation",
+    "~/Library/Application Support/Trader Workstation #{version.major_minor}",
   ]
 end

--- a/Casks/trader-workstation-stable.rb
+++ b/Casks/trader-workstation-stable.rb
@@ -35,7 +35,7 @@ cask "trader-workstation-stable" do
 
   uninstall quit:   "com.install4j.5889-6375-8446-2021",
             script: {
-              executable: "#{appdir}/Trader Workstation/Trader Workstation #{version.major_minor} Uninstaller.app/Contents/MacOS/JavaApplicationStub",
+              executable: "#{appdir}/Trader Workstation #{version.major_minor}/Trader Workstation #{version.major} Uninstaller.app/Contents/MacOS/JavaApplicationStub",
               args:       ["-q"],
             }
 


### PR DESCRIPTION
This adds apple silicon versions of trader workstation to the casks.

After making all changes to the cask:

- [x] `brew audit --cask --online --strict {{cask_file}}` is error-free.
- [x] `brew style --cask {{cask_file}}` is error-free.
