### PR TITLE
Add IBKR Desktop beta to auto update

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -26,7 +26,7 @@ jobs:
           sed -i "s/version .*/version $(cat stable)/g" Casks/trader-workstation-stable.rb
           sed -i "s/version .*/version $(cat beta)/g" Casks/trader-workstation-beta.rb
           sed -i "s/version .*/version $(cat ntws_latest)/g" Casks/ibkr-desktop-latest.rb
-          sed -i "s/version .*/version $(cat ntws_beta)/g" Casks/ibkr-desktop-stable.rb
+          sed -i "s/version .*/version $(cat ntws_beta)/g" Casks/ibkr-desktop-beta.rb
 
           if [[ `git status --porcelain` ]]; then
             echo "New versions detected"

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -19,12 +19,14 @@ jobs:
           curl "https://download2.interactivebrokers.com/installers/tws/stable-standalone/version.json?_=$MILLISECONDS&callback=twsstable_callback" | jq -R 'capture("\\((?<x>.*)\\)[^)]*$").x | fromjson | .buildVersion' > stable
           curl "https://download2.interactivebrokers.com/installers/tws/beta/version.json?_=$MILLISECONDS&callback=twsbetaupdatable_callback" | jq -R 'capture("\\((?<x>.*)\\)[^)]*$").x | fromjson | .buildVersion' > beta
           curl "https://download2.interactivebrokers.com/installers/ntws/latest-standalone/version.json?_=$MILLISECONDS&callback=ntwslatest_callback" | jq -R 'capture("\\((?<x>.*)\\)[^)]*$").x | fromjson | .buildVersion' > ntws_latest
+          curl "https://download2.interactivebrokers.com/installers/ntws/beta-standalone/version.json?_=$MILLISECONDS&callback=ntwsbeta_callback" | jq -R 'capture("\\((?<x>.*)\\)[^)]*$").x | fromjson | .buildVersion' > ntws_beta
       - name: Update Casks
         run: |-
           sed -i "s/version .*/version $(cat latest)/g" Casks/trader-workstation-latest.rb
           sed -i "s/version .*/version $(cat stable)/g" Casks/trader-workstation-stable.rb
           sed -i "s/version .*/version $(cat beta)/g" Casks/trader-workstation-beta.rb
           sed -i "s/version .*/version $(cat ntws_latest)/g" Casks/ibkr-desktop-latest.rb
+          sed -i "s/version .*/version $(cat ntws_beta)/g" Casks/ibkr-desktop-stable.rb
 
           if [[ `git status --porcelain` ]]; then
             echo "New versions detected"
@@ -32,10 +34,12 @@ jobs:
             echo "  Stable: $(cat stable)"
             echo "  Beta: $(cat beta)"
             echo "  IBKR Desktop: $(cat ntws_latest)"
+            echo "  IBKR Desktop Beta: $(cat ntws_beta)"
             rm latest
             rm stable
             rm beta
             rm ntws_latest
+            rm ntws_beta
 
             git config user.name "Auto Updater"
             git config user.email "actions@users.noreply.github.com"

--- a/Casks/ibkr-desktop-beta.rb
+++ b/Casks/ibkr-desktop-beta.rb
@@ -5,7 +5,7 @@ cask "ibkr-desktop-beta" do
   arch arm: "arm", intel: "x64"
   os = on_arch_conditional arm: "macos", intel: "macosx"
 
-  version "0.13.0g"
+  version "1.1a"
   sha256 :no_check
 
   url "https://download2.interactivebrokers.com/installers/ntws/beta-standalone/ntws-beta-standalone-#{os}-#{arch}.dmg"


### PR DESCRIPTION
The auto update job doesn't check for IBKR Desktop Beta. This PR adds the check

After making all changes to the cask:

- [x] `brew audit --cask --online --strict {{cask_file}}` is error-free.
- [x] `brew style --cask {{cask_file}}` is error-free.
