### PR TITLE
Fix CI after recent upstream change

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   ci-test:
     runs-on: ${{ matrix.os }}
+    env:
+      HOMEBREW_DEVELOPER: "1"
     strategy:
       matrix:
         os:


### PR DESCRIPTION
It seems https://github.com/Homebrew/brew/pull/20414 broke the CI by now allowing to use local packages for installing any more. Setting `HOMEBREW_DEVELOPER=1` should fix this.

After making all changes to the cask:

- [x] `brew audit --cask --online --strict {{cask_file}}` is error-free.
- [x] `brew style --cask {{cask_file}}` is error-free.
