### PR TITLE
Ensure auto update triggers continuous integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,10 @@
 name: Continuous Integration
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Auto-update casks on new releases"]
+    types:
+      - completed
   pull_request:
     paths:
       - ".github/workflows/**"
@@ -27,13 +28,12 @@ jobs:
       - name: Detect Casks to test
         id: detect
         run: |
-
           case "${{ github.event_name }}" in
           "pull_request")
             # For pull requests, check against the base branch
             changed=$(git diff --name-only origin/${{ github.base_ref }} HEAD | grep '^Casks/.*\.rb$' || true)
             ;;
-          "push")
+          "workflow_run")
             # For pushes, check against the previous commit
             changed=$(git diff --name-only HEAD^ HEAD | grep '^Casks/.*\.rb$' || true)
             ;;


### PR DESCRIPTION
This updates the trigger to ensure that the "Auto update casks" workflow triggers the CI as well if changes were made

After making all changes to the cask:

- [x] `brew audit --cask --online --strict {{cask_file}}` is error-free.
- [x] `brew style --cask {{cask_file}}` is error-free.
