### PR TITLE
Further workflow improvements

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   scheduled:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - name: Check out this repo
         uses: actions/checkout@v5

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   scheduled:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out this repo
         uses: actions/checkout@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,20 +33,23 @@ jobs:
           "pull_request")
             # For pull requests, check against the base branch
             changed=$(git diff --name-only origin/${{ github.base_ref }} HEAD | grep '^Casks/.*\.rb$' || true)
+
+            # if workflows were changed test all casks
+            if [[ $(git diff --name-only origin/${{ github.base_ref }} HEAD | grep '^\.github/workflows/.*\.yml$' || true) ]]; then
+              echo "Workflows changed, testing all casks."
+              changed=$(find Casks -name '*.rb' || true)
+            fi
             ;;
           "workflow_run")
             # For pushes, check against the previous commit, but only if the previous commit is less than 1 hour old
-
             prev_commit_time=$(git show -s --format=%ct HEAD^)
             echo "Previous commit time: $prev_commit_time"
 
             now=$(date +%s)
             echo "Current time: $now"
 
-            age=$(( now - prev_commit_time ))
-
             changed=""
-            if [[ $age -lt 3600 ]]; then
+            if [[ $(( now - prev_commit_time )) -lt 3600 ]]; then
               echo "Previous commit is less than 1 hour old, checking for changes."
               changed=$(git diff --name-only HEAD^ HEAD | grep '^Casks/.*\.rb$' || true)
             fi
@@ -70,6 +73,39 @@ jobs:
           echo "Detected casks: $json"
           echo "casks=$json" >> $GITHUB_OUTPUT
 
+  audit_casks:
+    name: "Audit ${{ matrix.cask }}"
+    needs: detect_casks
+    if: ${{ needs.detect_casks.outputs.casks != '[]' && needs.detect_casks.outputs.casks != '' }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        cask: ${{ fromJson(needs.detect_casks.outputs.casks) }}
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+        with:
+          stable: true
+          test-bot: false
+      - name: Cache Homebrew Gems
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ matrix.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ matrix.os }}-rubygems-
+      - name: Install Homebrew Gems
+        id: gems
+        run: brew install-bundler-gems
+        if: steps.cache.outputs.cache-hit != 'true'
+
+      - name: Style check cask
+        run: brew style --cask "${{ matrix.cask }}"
+      - name: Audit cask
+        run: brew audit --cask --online --strict "${{ matrix.cask }}"
+
   test_casks:
     name: "${{ matrix.os }}: Test ${{ matrix.cask }}"
     needs: detect_casks
@@ -83,7 +119,6 @@ jobs:
           - macos-13
           - macos-14
           - macos-15
-
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -91,7 +126,6 @@ jobs:
         with:
           stable: true
           test-bot: false
-
       - name: Cache Homebrew Gems
         id: cache
         uses: actions/cache@v4
@@ -99,20 +133,29 @@ jobs:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ matrix.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
           restore-keys: ${{ matrix.os }}-rubygems-
-
       - name: Install Homebrew Gems
         id: gems
         run: brew install-bundler-gems
         if: steps.cache.outputs.cache-hit != 'true'
 
-      - name: Style check cask
-        run: brew style --cask "${{ matrix.cask }}"
-
-      - name: Audit cask
-        run: brew audit --cask --online --strict "${{ matrix.cask }}"
-
       - name: Install cask
         run: brew install --cask "${{ matrix.cask }}"
-
       - name: Uninstall cask
         run: brew uninstall --cask "${{ matrix.cask }}"
+
+  ci-status:
+    name: CI Status
+    if: always()
+    needs:
+      - audit_casks
+      - test_casks
+    runs-on: ubuntu-24.04
+    env:
+      status: ${{ (( needs.audit_casks.result == 'success' && needs.test_casks.result == 'success' )) && 'success' || 'failure' }}
+    steps:
+      - name: Mark the job as succeeded
+        if: env.status == 'success'
+        run: exit 0
+      - name: Mark the job as failed
+        if: env.status != 'success'
+        run: exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,8 @@ name: Continuous Integration
 
 on:
   workflow_run:
-    workflows: ["Auto-update casks on new releases"]
+    workflows:
+      - "Auto-update casks on new releases"
     types:
       - completed
   pull_request:
@@ -16,7 +17,7 @@ on:
 
 jobs:
   detect_casks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       casks: ${{ steps.detect.outputs.casks }}
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/stale@v9
         with:


### PR DESCRIPTION
- Use ubuntu-24.04 instead of ubuntu-latest to avoid surprises in the future
- Run audit and style checks only once
- Add write permission to auto update cask workflow
- Extend CI workflow to run tests on all casks if workflows were updated

After making all changes to the cask:

- [x] `brew audit --cask --online --strict {{cask_file}}` is error-free.
- [x] `brew style --cask {{cask_file}}` is error-free.
