### PR TITLE
Replace macos-13 with macos-26 runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,9 +96,9 @@ jobs:
       matrix:
         cask: ${{ fromJson(needs.detect_casks.outputs.casks) }}
         os:
-          - macos-13
           - macos-14
           - macos-15
+          - macos-26
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew


### PR DESCRIPTION
### Motivation

`macos-13` is now deprecated and will soon be discontinued, `macos-26` is now available as beta.

### Description

Replace the `macos-13` runner in the CI with the `macos-26` runner.

After making all changes to the cask:

- [x] `brew style --cask {{ cask }}` is error-free.
- [x] `brew install {{ cask }}` and `brew uninstall {{ cask }}` complete without issues.
