### PR TITLE
Update Trader Workstation and IBKR Desktop casks

### DIFF
--- a/Casks/ibkr-desktop-latest.rb
+++ b/Casks/ibkr-desktop-latest.rb
@@ -5,7 +5,7 @@ cask "ibkr-desktop-latest" do
   arch arm: "arm", intel: "x64"
   os = on_arch_conditional arm: "macos", intel: "macosx"
 
-  version "3.1b"
+  version "3.2a"
   sha256 :no_check
 
   url "https://download2.interactivebrokers.com/installers/ntws/latest-standalone/ntws-latest-standalone-#{os}-#{arch}.dmg"


### PR DESCRIPTION
Automated update of Trader Workstation and IBKR Desktop casks.

- Latest: "10.46.1d"
- Stable: "10.45.1d"
- Beta: "10.47.0g"
- IBKR Desktop: "3.2a"
- IBKR Desktop Beta: "3.2a"