### PR TITLE
Update Trader Workstation and IBKR Desktop casks

### DIFF
--- a/Casks/trader-workstation-beta.rb
+++ b/Casks/trader-workstation-beta.rb
@@ -5,7 +5,7 @@ cask "trader-workstation-beta" do
   arch arm: "arm", intel: "x64"
   os = on_arch_conditional arm: "macos", intel: "macosx"
 
-  version "10.47.0l"
+  version "10.47.0o"
   sha256 :no_check
 
   url "https://download2.interactivebrokers.com/installers/tws/beta/tws-beta-#{os}-#{arch}.dmg"


### PR DESCRIPTION
Automated update of Trader Workstation and IBKR Desktop casks.

- Latest: "10.46.1f"
- Stable: "10.45.1e"
- Beta: "10.47.0o"
- IBKR Desktop: "3.2c"
- IBKR Desktop Beta: "3.2c"