### PR TITLE
Update Trader Workstation and IBKR Desktop casks

### DIFF
--- a/Casks/ibkr-desktop-beta.rb
+++ b/Casks/ibkr-desktop-beta.rb
@@ -5,7 +5,7 @@ cask "ibkr-desktop-beta" do
   arch arm: "arm", intel: "x64"
   os = on_arch_conditional arm: "macos", intel: "macosx"
 
-  version "3.2f"
+  version "3.3a"
   sha256 :no_check
 
   url "https://download2.interactivebrokers.com/installers/ntws/beta-standalone/ntws-beta-standalone-#{os}-#{arch}.dmg"

--- a/Casks/ibkr-desktop-beta.rb
+++ b/Casks/ibkr-desktop-beta.rb
@@ -24,9 +24,8 @@ cask "ibkr-desktop-beta" do
     end
   end
 
-  depends_on :macos
-
   conflicts_with cask: ["ibkr", "ibkr-desktop-latest"]
+  depends_on :macos
 
   installer script: {
     executable: "#{staged_path}/IBKR Desktop Installer.app/Contents/MacOS/JavaApplicationStub",

--- a/Casks/ibkr-desktop-beta.rb
+++ b/Casks/ibkr-desktop-beta.rb
@@ -2,44 +2,58 @@
 # frozen_string_literal: true
 
 cask "ibkr-desktop-beta" do
-  arch arm: "arm", intel: "x64"
-  os = on_arch_conditional arm: "macos", intel: "macosx"
+  arch arm: "-arm", intel: "x-x64"
 
   version "3.3a"
   sha256 :no_check
 
-  url "https://download2.interactivebrokers.com/installers/ntws/beta-standalone/ntws-beta-standalone-#{os}-#{arch}.dmg"
+  url "https://download2.interactivebrokers.com/installers/ntws/beta-standalone/ntws-beta-standalone-macos#{arch}.dmg"
   name "IBKR Desktop Beta"
   desc "Beta of IBKR Desktop"
   homepage "https://www.interactivebrokers.com/"
 
   livecheck do
     url "https://download2.interactivebrokers.com/installers/ntws/beta-standalone/version.json"
-    regex(/"buildVersion"\s*:\s*"(\d+(?:\.\d+)+[a-z]*)"/i)
+    regex(/callback\((.+)\)/i)
+    strategy :page_match do |page, regex|
+      match = page.match(regex)
+      next if match.blank?
+
+      json = Homebrew::Livecheck::Strategy::Json.parse_json(match[1])
+      json["buildVersion"]
+    end
   end
 
-  auto_updates true
+  depends_on :macos
+
+  conflicts_with cask: ["ibkr", "ibkr-desktop-latest"]
 
   installer script: {
     executable: "#{staged_path}/IBKR Desktop Installer.app/Contents/MacOS/JavaApplicationStub",
-    args:       ["-q"],
+    args:       [
+      "-dir", "#{appdir}/IBKR Desktop",
+      "-q"
+    ],
   }
 
-  uninstall_preflight do
-    ohai "Stopping all running instances of IBKR Desktop prior to uninstall"
-    system_command "/usr/bin/pkill", args: ["-f", "#{appdir}/IBKR Desktop/IBKR Desktop.app"]
-  rescue RuntimeError
-    ohai "No running instances of IBKR Desktop found"
-  end
-
-  uninstall script: {
-    executable: "#{appdir}/IBKR Desktop/IBKR Desktop Uninstaller.app/Contents/MacOS/JavaApplicationStub",
-    args:       ["-q"],
-  }
+  uninstall signal: [
+              ["TERM", "com.install4j.5557-0173-2810-0000"],
+              ["TERM", "com.install4j.5557-0173-2810-0000.22"],
+              ["TERM", "IBKR Desktop.app"],
+            ],
+            script: {
+              executable: "#{appdir}/IBKR Desktop/IBKR Desktop Uninstaller.app/Contents/MacOS/JavaApplicationStub",
+              args:       ["-q"],
+            }
 
   zap trash: [
     "#{appdir}/IBKR Desktop",
+    "~/Desktop/IBKR Desktop",
     "~/Jts",
     "~/Library/Application Support/IBKR Desktop",
+    "~/Library/HTTPStorages/com.install4j.5557-0173-2810-0000.6858",
+    "~/Library/Preferences/com.install4j.5557-0173-2810-0000.22.plist",
+    "~/Library/Preferences/com.install4j.5557-0173-2810-0000.uninstaller.plist",
+    "~/Library/Saved Application State/com.install4j.5557-0173-2810-0000.22.savedState",
   ]
 end

--- a/Casks/ibkr-desktop-latest.rb
+++ b/Casks/ibkr-desktop-latest.rb
@@ -24,9 +24,8 @@ cask "ibkr-desktop-latest" do
     end
   end
 
-  depends_on :macos
-
   conflicts_with cask: ["ibkr", "ibkr-desktop-beta"]
+  depends_on :macos
 
   installer script: {
     executable: "#{staged_path}/IBKR Desktop Installer.app/Contents/MacOS/JavaApplicationStub",

--- a/Casks/ibkr-desktop-latest.rb
+++ b/Casks/ibkr-desktop-latest.rb
@@ -2,44 +2,58 @@
 # frozen_string_literal: true
 
 cask "ibkr-desktop-latest" do
-  arch arm: "arm", intel: "x64"
-  os = on_arch_conditional arm: "macos", intel: "macosx"
+  arch arm: "-arm", intel: "x-x64"
 
   version "3.2f"
   sha256 :no_check
 
-  url "https://download2.interactivebrokers.com/installers/ntws/latest-standalone/ntws-latest-standalone-#{os}-#{arch}.dmg"
+  url "https://download2.interactivebrokers.com/installers/ntws/latest-standalone/ntws-latest-standalone-macos#{arch}.dmg"
   name "IBKR Desktop Latest"
   desc "Latest IBKR Desktop"
   homepage "https://www.interactivebrokers.com/"
 
   livecheck do
     url "https://download2.interactivebrokers.com/installers/ntws/latest-standalone/version.json"
-    regex(/"buildVersion"\s*:\s*"(\d+(?:\.\d+)+[a-z]*)"/i)
+    regex(/callback\((.+)\)/i)
+    strategy :page_match do |page, regex|
+      match = page.match(regex)
+      next if match.blank?
+
+      json = Homebrew::Livecheck::Strategy::Json.parse_json(match[1])
+      json["buildVersion"]
+    end
   end
 
-  auto_updates true
+  depends_on :macos
+
+  conflicts_with cask: ["ibkr", "ibkr-desktop-beta"]
 
   installer script: {
     executable: "#{staged_path}/IBKR Desktop Installer.app/Contents/MacOS/JavaApplicationStub",
-    args:       ["-q"],
+    args:       [
+      "-dir", "#{appdir}/IBKR Desktop",
+      "-q"
+    ],
   }
 
-  uninstall_preflight do
-    ohai "Stopping all running instances of IBKR Desktop prior to uninstall"
-    system_command "/usr/bin/pkill", args: ["-f", "#{appdir}/IBKR Desktop/IBKR Desktop.app"]
-  rescue RuntimeError
-    ohai "No running instances of IBKR Desktop found"
-  end
-
-  uninstall script: {
-    executable: "#{appdir}/IBKR Desktop/IBKR Desktop Uninstaller.app/Contents/MacOS/JavaApplicationStub",
-    args:       ["-q"],
-  }
+  uninstall signal: [
+              ["TERM", "com.install4j.5557-0173-2810-0000"],
+              ["TERM", "com.install4j.5557-0173-2810-0000.22"],
+              ["TERM", "IBKR Desktop.app"],
+            ],
+            script: {
+              executable: "#{appdir}/IBKR Desktop/IBKR Desktop Uninstaller.app/Contents/MacOS/JavaApplicationStub",
+              args:       ["-q"],
+            }
 
   zap trash: [
     "#{appdir}/IBKR Desktop",
+    "~/Desktop/IBKR Desktop",
     "~/Jts",
     "~/Library/Application Support/IBKR Desktop",
+    "~/Library/HTTPStorages/com.install4j.5557-0173-2810-0000.6858",
+    "~/Library/Preferences/com.install4j.5557-0173-2810-0000.22.plist",
+    "~/Library/Preferences/com.install4j.5557-0173-2810-0000.uninstaller.plist",
+    "~/Library/Saved Application State/com.install4j.5557-0173-2810-0000.22.savedState",
   ]
 end

--- a/Casks/trader-workstation-beta.rb
+++ b/Casks/trader-workstation-beta.rb
@@ -5,7 +5,7 @@ cask "trader-workstation-beta" do
   arch arm: "arm", intel: "x64"
   os = on_arch_conditional arm: "macos", intel: "macosx"
 
-  version "10.48.0c"
+  version "10.48.0d"
   sha256 :no_check
 
   url "https://download2.interactivebrokers.com/installers/tws/beta/tws-beta-#{os}-#{arch}.dmg"


### PR DESCRIPTION
Automated update of Trader Workstation and IBKR Desktop casks.

- Latest: "10.47.1c"
- Stable: "10.45.1g"
- Beta: "10.48.0d"
- IBKR Desktop: "3.2f"
- IBKR Desktop Beta: "3.3a"