### PR TITLE
Update Trader Workstation and IBKR Desktop casks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,8 @@ jobs:
         id: gems
         run: brew install-bundler-gems
         if: steps.cache.outputs.cache-hit != 'true'
+      - name: Trust fasmat/trader-workstation tap
+        run: brew trust fasmat/trader-workstation
       - name: Style check cask
         run: brew style --casks ${{ join(fromJson(needs.detect_casks.outputs.casks), ' ') }}
       - name: Audit cask
@@ -116,7 +118,8 @@ jobs:
         id: gems
         run: brew install-bundler-gems
         if: steps.cache.outputs.cache-hit != 'true'
-
+      - name: Trust fasmat/trader-workstation tap
+        run: brew trust fasmat/trader-workstation
       - name: Install cask
         run: brew install --cask "${{ matrix.cask }}"
       - name: Uninstall cask

--- a/Casks/ibkr-desktop-beta.rb
+++ b/Casks/ibkr-desktop-beta.rb
@@ -4,7 +4,7 @@
 cask "ibkr-desktop-beta" do
   arch arm: "-arm", intel: "x-x64"
 
-  version "3.3d"
+  version "3.3e"
   sha256 :no_check
 
   url "https://download2.interactivebrokers.com/installers/ntws/beta-standalone/ntws-beta-standalone-macos#{arch}.dmg"


### PR DESCRIPTION
Automated update of Trader Workstation and IBKR Desktop casks.

- Latest: "10.47.1d"
- Stable: "10.45.1g"
- Beta: "10.48.0l"
- IBKR Desktop: "3.2f"
- IBKR Desktop Beta: "3.3e"