### PR TITLE
Update Trader Workstation and IBKR Desktop casks

### DIFF
--- a/Casks/ibkr-desktop-beta.rb
+++ b/Casks/ibkr-desktop-beta.rb
@@ -4,7 +4,7 @@
 cask "ibkr-desktop-beta" do
   arch arm: "-arm", intel: "x-x64"
 
-  version "3.3f"
+  version "3.3h"
   sha256 :no_check
 
   url "https://download2.interactivebrokers.com/installers/ntws/beta-standalone/ntws-beta-standalone-macos#{arch}.dmg"

--- a/Casks/trader-workstation-beta.rb
+++ b/Casks/trader-workstation-beta.rb
@@ -28,7 +28,7 @@ cask "trader-workstation-beta" do
 
   uninstall_preflight do
     ohai "Stopping all running instances of Trader Workstation prior to uninstall"
-    system_command "/usr/bin/pkill", args: ["-f", "~/Applications/Trader Workstation/Trader Workstation.app"]
+    system_command "/usr/bin/pkill", args: ["-f", "#{appdir}/Trader Workstation/Trader Workstation.app"]
   rescue RuntimeError
     ohai "No running instances of Trader Workstation found"
   end
@@ -39,8 +39,8 @@ cask "trader-workstation-beta" do
   }
 
   zap trash: [
-    "/Applications/Trader Workstation",  
-    "~/Applications/Trader Workstation",  
+    "/Applications/Trader Workstation",
+    "~/Applications/Trader Workstation",
     "~/Jts",
     "~/Library/Application Support/Trader Workstation",
   ]

--- a/Casks/trader-workstation-beta.rb
+++ b/Casks/trader-workstation-beta.rb
@@ -39,8 +39,8 @@ cask "trader-workstation-beta" do
   }
 
   zap trash: [
-    "~/Applications/Trader Workstation",
-    "/Applications/Trader Workstation",
+    "/Applications/Trader Workstation",  
+    "~/Applications/Trader Workstation",  
     "~/Jts",
     "~/Library/Application Support/Trader Workstation",
   ]

--- a/Casks/trader-workstation-beta.rb
+++ b/Casks/trader-workstation-beta.rb
@@ -28,18 +28,19 @@ cask "trader-workstation-beta" do
 
   uninstall_preflight do
     ohai "Stopping all running instances of Trader Workstation prior to uninstall"
-    system_command "/usr/bin/pkill", args: ["-f", "#{appdir}/Trader Workstation/Trader Workstation.app"]
+    system_command "/usr/bin/pkill", args: ["-f", "~/Applications/Trader Workstation/Trader Workstation.app"]
   rescue RuntimeError
     ohai "No running instances of Trader Workstation found"
   end
 
   uninstall script: {
-    executable: "#{appdir}/Trader Workstation/Trader Workstation Uninstaller.app/Contents/MacOS/JavaApplicationStub",
+    executable: "~/Applications/Trader Workstation/Trader Workstation Uninstaller.app/Contents/MacOS/JavaApplicationStub",
     args:       ["-q"],
   }
 
   zap trash: [
-    "#{appdir}/Trader Workstation",
+    "~/Applications/Trader Workstation",
+    "/Applications/Trader Workstation",
     "~/Jts",
     "~/Library/Application Support/Trader Workstation",
   ]

--- a/Casks/trader-workstation-beta.rb
+++ b/Casks/trader-workstation-beta.rb
@@ -5,7 +5,7 @@ cask "trader-workstation-beta" do
   arch arm: "arm", intel: "x64"
   os = on_arch_conditional arm: "macos", intel: "macosx"
 
-  version "10.48.0l"
+  version "10.48.0n"
   sha256 :no_check
 
   url "https://download2.interactivebrokers.com/installers/tws/beta/tws-beta-#{os}-#{arch}.dmg"

--- a/Casks/trader-workstation-latest.rb
+++ b/Casks/trader-workstation-latest.rb
@@ -5,7 +5,7 @@ cask "trader-workstation-latest" do
   arch arm: "arm", intel: "x64"
   os = on_arch_conditional arm: "macos", intel: "macosx"
 
-  version "10.47.1d"
+  version "10.47.1e"
   sha256 :no_check
 
   url "https://download2.interactivebrokers.com/installers/tws/latest-standalone/tws-latest-standalone-#{os}-#{arch}.dmg"


### PR DESCRIPTION
Automated update of Trader Workstation and IBKR Desktop casks.

- Latest: "10.47.1e"
- Stable: "10.45.1g"
- Beta: "10.48.0n"
- IBKR Desktop: "3.2f"
- IBKR Desktop Beta: "3.3h"