### PR TITLE
Update Trader Workstation and IBKR Desktop casks

### DIFF
--- a/Casks/trader-workstation-latest.rb
+++ b/Casks/trader-workstation-latest.rb
@@ -5,7 +5,7 @@ cask "trader-workstation-latest" do
   arch arm: "arm", intel: "x64"
   os = on_arch_conditional arm: "macos", intel: "macosx"
 
-  version "10.48.1d"
+  version "10.48.1e"
   sha256 :no_check
 
   url "https://download2.interactivebrokers.com/installers/tws/latest-standalone/tws-latest-standalone-#{os}-#{arch}.dmg"


### PR DESCRIPTION
Automated update of Trader Workstation and IBKR Desktop casks.

- Latest: "10.48.1e"
- Stable: "10.45.1h"
- Beta: "10.49.0g"
- IBKR Desktop: "3.3k"
- IBKR Desktop Beta: "3.3k"