### PR TITLE
Update Trader Workstation and IBKR Desktop casks

### DIFF
--- a/Casks/trader-workstation-stable.rb
+++ b/Casks/trader-workstation-stable.rb
@@ -5,7 +5,7 @@ cask "trader-workstation-stable" do
   arch arm: "arm", intel: "x64"
   os = on_arch_conditional arm: "macos", intel: "macosx"
 
-  version "10.45.1h"
+  version "10.45.1i"
   sha256 :no_check
 
   url "https://download2.interactivebrokers.com/installers/tws/stable-standalone/tws-stable-standalone-#{os}-#{arch}.dmg"


### PR DESCRIPTION
Automated update of Trader Workstation and IBKR Desktop casks.

- Latest: "10.48.1e"
- Stable: "10.45.1i"
- Beta: "10.49.0i"
- IBKR Desktop: "3.3k"
- IBKR Desktop Beta: "3.3k"