### PR TITLE
Update Trader Workstation and IBKR Desktop casks

### DIFF
--- a/Casks/trader-workstation-beta.rb
+++ b/Casks/trader-workstation-beta.rb
@@ -5,7 +5,7 @@ cask "trader-workstation-beta" do
   arch arm: "arm", intel: "x64"
   os = on_arch_conditional arm: "macos", intel: "macosx"
 
-  version "10.49.1b"
+  version "10.49.1c"
   sha256 :no_check
 
   url "https://download2.interactivebrokers.com/installers/tws/beta/tws-beta-#{os}-#{arch}.dmg"

--- a/Casks/trader-workstation-latest.rb
+++ b/Casks/trader-workstation-latest.rb
@@ -5,7 +5,7 @@ cask "trader-workstation-latest" do
   arch arm: "arm", intel: "x64"
   os = on_arch_conditional arm: "macos", intel: "macosx"
 
-  version "10.48.1f"
+  version "10.49.1c"
   sha256 :no_check
 
   url "https://download2.interactivebrokers.com/installers/tws/latest-standalone/tws-latest-standalone-#{os}-#{arch}.dmg"


### PR DESCRIPTION
Automated update of Trader Workstation and IBKR Desktop casks.

- Latest: "10.49.1c"
- Stable: "10.45.1i"
- Beta: "10.49.1c"
- IBKR Desktop: "3.3k"
- IBKR Desktop Beta: "3.4b"