### PR TITLE
Update Trader Workstation and IBKR Desktop casks

### DIFF
--- a/Casks/ibkr-desktop-beta.rb
+++ b/Casks/ibkr-desktop-beta.rb
@@ -4,7 +4,7 @@
 cask "ibkr-desktop-beta" do
   arch arm: "-arm", intel: "x-x64"
 
-  version "3.4b"
+  version "3.4c"
   sha256 :no_check
 
   url "https://download2.interactivebrokers.com/installers/ntws/beta-standalone/ntws-beta-standalone-macos#{arch}.dmg"

--- a/Casks/trader-workstation-beta.rb
+++ b/Casks/trader-workstation-beta.rb
@@ -5,7 +5,7 @@ cask "trader-workstation-beta" do
   arch arm: "arm", intel: "x64"
   os = on_arch_conditional arm: "macos", intel: "macosx"
 
-  version "10.49.1c"
+  version "10.50.0a"
   sha256 :no_check
 
   url "https://download2.interactivebrokers.com/installers/tws/beta/tws-beta-#{os}-#{arch}.dmg"


### PR DESCRIPTION
Automated update of Trader Workstation and IBKR Desktop casks.

- Latest: "10.49.1c"
- Stable: "10.45.1i"
- Beta: "10.50.0a"
- IBKR Desktop: "3.3k"
- IBKR Desktop Beta: "3.4c"